### PR TITLE
remove no need arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,17 @@ A simple script to wait ecs run-task completion to run task synchronously
 ##### ecs-run-task-waiter #####
 Simple script for waiting run-task execution completion on Amazon Elastic Container Service
 
-One of the following is required:
+Optional arguments:
     -r | --region                AWS Region Name. May also be set as environment variable AWS_DEFAULT_REGION
     -p | --profile               AWS Profile to use - If you set this aws-access-key, aws-secret-key and region are needed
-    -c | --cluster               Name of ECS cluster
-Optional arguments:
-    --log-group-name             Name of the log group
-    --log-stream-prefix          Prefix of log stream
-    -t | --timeout               Default is 10min
+    --output-log                 Output task logs. Default false
+    -t | --timeout               Default is 90s. Script monitors ECS Service for new task definition to be running.
     -v | --verbose               Verbose output
 Requirements:
     aws:  AWS Command Line Interface
     jq:   Command-line JSON processor
 Examples:
-  aws ecs run-task-waiter --profile foo --region ap-northeast-1  --cluster mycluster --task-definition mytask \
+  aws ecs run-task --profile foo --region ap-northeast-1 --cluster mycluster --task-definition mytask \
     --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-abc"],"securityGroups":["sg-123"],"assignPublicIp":"ENABLED"}}' \
-    --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo -c mycluster
+    --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo
 ````

--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -28,7 +28,7 @@ Requirements:
     aws:  AWS Command Line Interface
     jq:   Command-line JSON processor
 Examples:
-  aws ecs run-task-waiter --profile foo --region ap-northeast-1  --cluster mycluster --task-definition mytask --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-abc"],"securityGroups":["sg-123"],"assignPublicIp":"ENABLED"}}' --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo -c mycluster
+  aws ecs run-task --profile foo --region ap-northeast-1 --cluster mycluster --task-definition mytask --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-abc"],"securityGroups":["sg-123"],"assignPublicIp":"ENABLED"}}' --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo
 EOM
 
   exit 3

--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -15,10 +15,9 @@ function usage() {
 ##### ecs-run-task-waiter #####
 Simple script for waiting run-task execution completion on Amazon Elastic Container Service
 
-One of the following is required:
+Optional arguments:
     -r | --region                AWS Region Name. May also be set as environment variable AWS_DEFAULT_REGION
     -p | --profile               AWS Profile to use - If you set this aws-access-key, aws-secret-key and region are needed
-Optional arguments:
     --output-log                 Output task logs. Default false
     -t | --timeout               Default is 90s. Script monitors ECS Service for new task definition to be running.
     -v | --verbose               Verbose output
@@ -26,7 +25,9 @@ Requirements:
     aws:  AWS Command Line Interface
     jq:   Command-line JSON processor
 Examples:
-  aws ecs run-task --profile foo --region ap-northeast-1 --cluster mycluster --task-definition mytask --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-abc"],"securityGroups":["sg-123"],"assignPublicIp":"ENABLED"}}' --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo
+  aws ecs run-task --profile foo --region ap-northeast-1 --cluster mycluster --task-definition mytask \\
+    --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-abc"],"securityGroups":["sg-123"],"assignPublicIp":"ENABLED"}}' \\
+    --launch-type FARGATE | ecs-run-task-waiter -r ap-northeast-1  -p foo
 EOM
 
   exit 3

--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -63,9 +63,6 @@ function buildLogStreamName() {
 # main
 #
 
-# If no args are provided, display usage information
-if [ $# == 0 ]; then usage; fi
-
 # Loop through arguments, two at a time for key and value
 while [[ $# -gt 0 ]]
 do

--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -3,8 +3,7 @@
 set -ue
 
 # default values
-LOG_GROUP_NAME=false
-LOG_STREAM_PREFIX=false
+OUTPUT_LOG=false
 TIMEOUT=600
 AWS_CLI=$(which aws)
 AWS_ECS="$AWS_CLI --output json ecs"
@@ -20,8 +19,7 @@ One of the following is required:
     -r | --region                AWS Region Name. May also be set as environment variable AWS_DEFAULT_REGION
     -p | --profile               AWS Profile to use - If you set this aws-access-key, aws-secret-key and region are needed
 Optional arguments:
-    --log-group-name             Name of the log group
-    --log-stream-prefix          Prefix of log stream
+    --output-log                 Output task logs. Default false
     -t | --timeout               Default is 90s. Script monitors ECS Service for new task definition to be running.
     -v | --verbose               Verbose output
 Requirements:
@@ -53,16 +51,11 @@ function assertRequiredArgumentsSet() {
 
 }
 
-function isOutputLog() {
-  [ $LOG_GROUP_NAME != false ] && [ $LOG_STREAM_PREFIX != false ]
-  return $?
-}
-
 function buildLogStreamName() {
   task_arn=$1
   task_id="$(echo $task_arn | awk -F / '{print $2}')"
   container_name=$2
-  prefix=$LOG_STREAM_PREFIX
+  prefix=$3
   echo "${prefix}/${container_name}/${task_id}"
 }
 
@@ -87,13 +80,8 @@ do
       AWS_PROFILE="$2"
       shift # past argument
       ;;
-    --log-group-name)
-      LOG_GROUP_NAME="$2"
-      shift # past argument
-      ;;
-    --log-stream-prefix)
-      LOG_STREAM_PREFIX="$2"
-      shift # past argument
+    --output-log)
+      OUTPUT_LOG=true
       ;;
     -t|--timeout)
       TIMEOUT="$2"
@@ -131,8 +119,12 @@ echo "clusterArn: ${cluster_arn}"
 task_arn=$(echo $task | jq -r .taskArn)
 echo "taskArn: ${task_arn}"
 
+task_definition_arn=$(echo $task | jq -r .taskDefinitionArn)
+echo "taskDefinitionArn: ${task_definition_arn}"
+
 container="$(echo $task | jq .containers[0])"
 echo "containerArn: $(echo $container | jq -r .containerArn)"
+
 container_name="$(echo $container | jq -r .name)"
 echo "container name: ${container_name}"
 
@@ -168,12 +160,15 @@ if [[ $exit_code -ne 0 ]]; then
   echo 'ERROR: run-task failed' > /dev/stderr
 fi
 
-isOutputLog
-if [ $? -eq 0 ]; then
+if [ $OUTPUT_LOG == true ]; then
+  describe_tasks_out="$(${AWS_ECS} describe-task-definition --task-definition ${task_definition_arn})"
+  log_options="$(echo $describe_tasks_out | jq .taskDefinition.containerDefinitions[0].logConfiguration.options)"
+  log_group_name="$(echo $log_options | jq -r '.["awslogs-group"]')"
+  log_stream_prefix="$(echo $log_options | jq -r '.["awslogs-stream-prefix"]')"
+  log_stream_name="$(buildLogStreamName $task_arn $container_name $log_stream_prefix)"
   echo
-  log_stream_name="$(buildLogStreamName $task_arn $container_name)"
   echo "run-task output from the log stream ${log_stream_name}:"
-  $AWS_LOGS get-log-events --log-group-name $LOG_GROUP_NAME --log-stream-name $log_stream_name | jq -r '.events | .[] | .message'
+  $AWS_LOGS get-log-events --log-group-name $log_group_name --log-stream-name $log_stream_name | jq -r '.events | .[] | .message'
 fi
 
 exit $exit_code

--- a/ecs-run-task-waiter
+++ b/ecs-run-task-waiter
@@ -3,7 +3,6 @@
 set -ue
 
 # default values
-CLUSTER=false
 LOG_GROUP_NAME=false
 LOG_STREAM_PREFIX=false
 TIMEOUT=600
@@ -20,7 +19,6 @@ Simple script for waiting run-task execution completion on Amazon Elastic Contai
 One of the following is required:
     -r | --region                AWS Region Name. May also be set as environment variable AWS_DEFAULT_REGION
     -p | --profile               AWS Profile to use - If you set this aws-access-key, aws-secret-key and region are needed
-    -c | --cluster               Name of ECS cluster
 Optional arguments:
     --log-group-name             Name of the log group
     --log-stream-prefix          Prefix of log stream
@@ -51,11 +49,6 @@ function assertRequiredArgumentsSet() {
   else
     AWS_ECS="$AWS_ECS --profile $AWS_PROFILE"
     AWS_LOGS="$AWS_LOGS --profile $AWS_PROFILE"
-  fi
-
-  if [ $CLUSTER == false ]; then
-    echo "CLUSTER is required. You can pass the value using -c or --cluster"
-    exit 7
   fi
 
 }
@@ -92,10 +85,6 @@ do
       ;;
     -p|--profile)
       AWS_PROFILE="$2"
-      shift # past argument
-      ;;
-    -c|--cluster)
-      CLUSTER="$2"
       shift # past argument
       ;;
     --log-group-name)
@@ -136,6 +125,9 @@ fi
 
 run_task_out="$(cat -)"
 task="$(echo $run_task_out | jq .tasks[0])"
+cluster_arn=$(echo $task | jq -r .clusterArn)
+echo "clusterArn: ${cluster_arn}"
+
 task_arn=$(echo $task | jq -r .taskArn)
 echo "taskArn: ${task_arn}"
 
@@ -150,7 +142,7 @@ exit_code=1
 every=10
 i=0
 while [ $i -lt $TIMEOUT ]; do
-  describe_tasks_out="$(${AWS_ECS} describe-tasks --cluster ${CLUSTER} --tasks ${task_arn})"
+  describe_tasks_out="$(${AWS_ECS} describe-tasks --cluster ${cluster_arn} --tasks ${task_arn})"
   t="$(echo $describe_tasks_out | jq .tasks[0])"
   c="$(echo $t | jq .containers[0])"
   st="$(echo $c | jq -r .lastStatus)"


### PR DESCRIPTION
`--cluster`, `--log-group-name` and `--log-stream-prefix` can be got from `run-task` output.

So remove those arguments and add `--output-log`.